### PR TITLE
pointerify the rollingstate receiver

### DIFF
--- a/ssdeep.go
+++ b/ssdeep.go
@@ -29,7 +29,7 @@ type rollingState struct {
 	n      uint32
 }
 
-func (rs rollingState) rollSum() uint32 {
+func (rs *rollingState) rollSum() uint32 {
 	return rs.h1 + rs.h2 + rs.h3
 }
 


### PR DESCRIPTION
```
$ benchcmp old.txt new.txt
benchmark                  old ns/op     new ns/op     delta
BenchmarkDistance-4        10032         10038         +0.06%
BenchmarkRollingHash-4     3.23          3.24          +0.31%
BenchmarkSumHash-4         33.9          34.0          +0.29%
BenchmarkBlockSize-4       11.2          10.1          -9.82%
BenchmarkProcessByte-4     28.6          19.1          -33.22%
```