### PR TITLE
Expose errors variables

### DIFF
--- a/score.go
+++ b/score.go
@@ -1,10 +1,18 @@
 package ssdeep
 
 import (
-	"math"
-	"strings"
-	"strconv"
 	"errors"
+	"math"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrEmptyHash is returned when no hash string is provided for scoring.
+	ErrEmptyHash = errors.New("empty string")
+
+	// ErrInvalidFormat is returned when a hash string is malformed.
+	ErrInvalidFormat = errors.New("invalid ssdeep format")
 )
 
 // Distance computes the match score between two fuzzy hash signatures.
@@ -44,19 +52,19 @@ func Distance(hash1, hash2 string) (score int, err error) {
 
 func splitSsdeep(hash string) (blockSize int, hashString1, hashString2 string, err error) {
 	if hash == "" {
-		err = errors.New("empty string")
+		err = ErrEmptyHash
 		return
 	}
 
 	parts := strings.Split(hash, ":")
 	if len(parts) != 3 {
-		err = errors.New("invalid ssdeep format")
+		err = ErrInvalidFormat
 		return
 	}
 
 	blockSize, err = strconv.Atoi(parts[0])
 	if err != nil {
-		err = errors.New("invalid ssdeep format")
+		err = ErrInvalidFormat
 		return
 	}
 

--- a/ssdeep.go
+++ b/ssdeep.go
@@ -9,6 +9,14 @@ import (
 	"os"
 )
 
+var (
+	// ErrFileTooSmall is returned when a file contains too few bytes.
+	ErrFileTooSmall = errors.New("did not process files large enough to produce meaningful results")
+
+	// ErrBlockSizeTooSmall is returned when a file can't produce a large enough block size.
+	ErrBlockSizeTooSmall = errors.New("unable to establish a sufficient block size")
+)
+
 const (
 	rollingWindow uint32 = 7
 	blockMin             = 3
@@ -116,14 +124,6 @@ type Reader interface {
 	io.Seeker
 	io.Reader
 }
-
-var (
-	// ErrFileTooSmall is returned when a file contains too few bytes.
-	ErrFileTooSmall = errors.New("did not process files large enough to produce meaningful results")
-
-	// ErrBlockSizeTooSmall is returned when a file can't produce a large enough block size.
-	ErrBlockSizeTooSmall = errors.New("unable to establish a sufficient block size")
-)
 
 func (state *ssdeepState) process(r *bufio.Reader) {
 	state.newRollingState()


### PR DESCRIPTION
Can check for these errors via equality rather than looking at the error message string.