### PR TITLE
fix: digest() drops final hash character when FNV tail value is zero

### DIFF
--- a/ssdeep.go
+++ b/ssdeep.go
@@ -74,6 +74,7 @@ type blockHashState struct {
 	blockSize              uint32
 	blockHash1, blockHash2 byte
 	tail1, tail2           byte
+	hasTail1, hasTail2     bool
 }
 
 func newSSDEEPState() ssdeepState {
@@ -144,14 +145,22 @@ func (state *ssdeepState) processByte(b byte) {
 			if len(block.hashString) < spamSumLength-1 {
 				block.hashString = append(block.hashString, block.tail1)
 				block.tail1 = 0
+				block.hasTail1 = false
 				block.blockHash1 = hashInit
 				if len(block.hashString) < halfspamSumLength {
 					block.blockHash2 = hashInit
 					block.tail2 = 0
+					block.hasTail2 = false
+				} else {
+					block.hasTail2 = true
 				}
-			} else if state.isStartBlockFull() {
-				state.iStart++
-				state.bsizeMask = (state.bsizeMask << 1) + 1
+			} else {
+				block.hasTail1 = true
+				block.hasTail2 = true
+				if state.isStartBlockFull() {
+					state.iStart++
+					state.bsizeMask = (state.bsizeMask << 1) + 1
+				}
 			}
 		}
 	}
@@ -223,10 +232,10 @@ func (state *ssdeepState) digest() (string, error) {
 		bl1.hashString = append(bl1.hashString, bl1.blockHash1)
 		bl2.hashString = append(bl2.hashString, bl2.blockHash2)
 	} else {
-		if len(bl1.hashString) == spamSumLength-1 && bl1.tail1 != 0 {
+		if bl1.hasTail1 {
 			bl1.hashString = append(bl1.hashString, bl1.tail1)
 		}
-		if bl2.tail2 != 0 {
+		if bl2.hasTail2 {
 			bl2.hashString = append(bl2.hashString, bl2.tail2)
 		}
 	}


### PR DESCRIPTION
The tail1/tail2 values in digest() were checked with != 0 to determine if they held valid data. However, 0 is a valid FNV hash output that maps to b64[0]='A'. The C reference implementation stores b64[h] in its digest array and checks != '\0', which always passes for valid hash values.

Added hasTail1/hasTail2 boolean flags to explicitly track whether tail values were set during a trigger at full digest capacity.

Validated against the C reference (ssdeep-project/ssdeep) on 103,001 test files with zero mismatches. The unpatched code produces 75 mismatches, all following the same pattern: a trailing 'A' (b64[0]) dropped from the first hash part.

Fixes #23