### PR TITLE
fix: prevent index out-of-range panic in hasCommonSubstring

### DIFF
--- a/score.go
+++ b/score.go
@@ -92,6 +92,9 @@ func hasCommonSubstring(s1, s2 string) bool {
 	s1Len := len(s1)
 	s2Len := len(s2)
 	hashes := make([]uint32, (spamSumLength - (rollingWindow - 1)))
+	if s1Len > spamSumLength || s2Len > spamSumLength {
+		return false
+	}
 	if s1Len < rollingWindow || s2Len < rollingWindow {
 		return false
 	}

--- a/score_test.go
+++ b/score_test.go
@@ -1,6 +1,7 @@
 package ssdeep
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -78,6 +79,31 @@ func TestInvalidHash2(t *testing.T) {
 	if d != 0 {
 		t.Errorf("hash1 and hash2 are nil: %d", d)
 	}
+}
+
+// Crash seed: body length 65 triggers index out of range [58] with length 58.
+func TestHasCommonSubstringOOB(t *testing.T) {
+	s1 := "3:" + strings.Repeat("0", 65) + ":"
+	s2 := "3:0000000:"
+	// Must not panic.
+	_, err := Distance(s1, s2)
+	if err != nil {
+		t.Logf("Distance returned error (acceptable): %v", err)
+	}
+}
+
+// FuzzSSDeepDistanceDirect feeds arbitrary hash strings directly to Distance.
+// The library must not panic; an error return is acceptable.
+func FuzzSSDeepDistanceDirect(f *testing.F) {
+	f.Add("3:"+strings.Repeat("0", 65)+":", "3:0000000:")
+	f.Add("3:abc:abc", "3:abc:abc")
+	f.Add("", "")
+	f.Add("not-a-hash", "also-not-a-hash")
+
+	f.Fuzz(func(t *testing.T, s1, s2 string) {
+		// Must not panic.
+		_, _ = Distance(s1, s2)
+	})
 }
 
 func BenchmarkDistance(b *testing.B) {


### PR DESCRIPTION
:wave:, I was looking a some of my app and discovered a small bugs in the library.
So here's a fix and some description of the issue!

I took the liberty to add a fuzz test as I don't think you have any fuzz test in here yet. I've run it for a bit after the fix and didn't seem to find any other bugs :)

## Description

`Distance` parses hash strings by splitting on `:` but imposes no length cap on the body segments. `hasCommonSubstring` allocates a `hashes` slice of fixed size `spamSumLength - (rollingWindow - 1)` = 64 - 6 = 58, then writes into it at index `i-(rollingWindow-1)` while looping `for i = rollingWindow-1; i < s1Len; i++`. When the hash body is 65 or more characters long the index reaches 58, which is out of bounds, and the runtime raises a fatal panic.

## Crash Input
I've added a regression test for this case, but for convenience:

```go
s1 := "3:" + strings.Repeat("0", 65) + ":"
s2 := "3:0000000:"
ssdeep.Distance(s1, s2) // panic: runtime error: index out of range [58] with length 58
```

## Root Cause

In `score.go:104`:

```go
// Vulnerable:
func hasCommonSubstring(s1, s2 string) bool {
    // ...
    hashes := make([]uint32, (spamSumLength - (rollingWindow - 1))) // length = 58
    // ...
    for i = rollingWindow - 1; i < s1Len; i++ {
        state.rollHash(s1[i])
        hashes[i-(rollingWindow-1)] = state.rollSum() // panics when i-(rollingWindow-1) >= 58
    }
    // ...
}
```